### PR TITLE
fix(#8026): validate empty branding doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,4 @@ user-password-change.txt
 user-password-change.csv
 /scripts/build/helm/tests/integration-k3d-values.yaml
 /tests/e2e/visual/images/*.png
-
+.envrc

--- a/admin/src/js/controllers/images-branding.js
+++ b/admin/src/js/controllers/images-branding.js
@@ -25,8 +25,16 @@ angular.module('controllers').controller('ImagesBrandingCtrl',
       return DB().get(DOC_ID, { attachments: true })
         .then(doc => {
           $scope.doc = doc;
-          $scope.favicon = doc._attachments[doc.resources.favicon];
-          $scope.icon = doc._attachments[doc.resources.icon];
+          if (!Object.hasOwn($scope.doc, 'title')) {
+            $scope.doc.title = '';
+          }
+          if (!Object.hasOwn($scope.doc, 'resources')) {
+            $scope.doc.resources = {};
+          }
+          if (Object.hasOwn(doc, '_attachments') && Object.hasOwn(doc, 'resources')) {
+            $scope.favicon = doc._attachments[doc.resources.favicon];
+            $scope.icon = doc._attachments[doc.resources.icon];
+          }
         })
         .catch(err => {
           $log.error('Error fetching resources file', err);
@@ -36,7 +44,7 @@ angular.module('controllers').controller('ImagesBrandingCtrl',
         });
     };
 
-    getResourcesDoc();
+    this.$onInit = getResourcesDoc;
 
     const validateTitle = () => {
       if (!$scope.doc.title) {
@@ -101,14 +109,14 @@ angular.module('controllers').controller('ImagesBrandingCtrl',
       if (!$scope.doc) {
         $log.error('Doc not found on scope when saving branding images');
         $translate('Error saving settings').then(msg => $scope.error = msg);
-        return;
+        return Promise.resolve();
       }
 
       if (!validateTitle() ||
           !updateLogo() ||
           !updateFavicon() ||
           !updateIcon()) {
-        return;
+        return Promise.resolve();
       }
 
       removeObsoleteAttachments();

--- a/admin/tests/unit/controllers/images-branding.spec.js
+++ b/admin/tests/unit/controllers/images-branding.spec.js
@@ -1,0 +1,54 @@
+describe('ImagesBrandingCtrl', function () {
+
+  'use strict';
+
+  let $controller;
+  let $rootScope;
+
+  const $log = {error: sinon.stub()};
+  const $translate = sinon.stub();
+  const AddAttachment = sinon.stub();
+  const db = {
+    get: sinon.stub(),
+    put: sinon.stub()
+  };
+  const Translate = {fieldIsRequired: sinon.stub()};
+
+  let imagesBrandingController;
+  let $scope;
+
+  beforeEach(module('adminApp'));
+
+  beforeEach(inject(function (_$controller_, _$rootScope_) {
+    $controller = _$controller_;
+    $rootScope = _$rootScope_;
+
+    $scope = $rootScope.$new(true);
+    imagesBrandingController = () => $controller('ImagesBrandingCtrl', {
+      $log,
+      $scope,
+      $translate,
+      AddAttachment,
+      DB: () => db,
+      Translate
+    });
+  }));
+
+  afterEach(() => sinon.restore());
+
+  describe('Submit', () => {
+    //https://github.com/medic/cht-core/issues/8026
+    it('should not fail when branding doc is empty', async () => {
+
+      db.get.withArgs('branding', {attachments: true}).resolves({});
+      $translate.resolves('some message');
+      Translate.fieldIsRequired.resolves('some validation messsage');
+
+      const controller = await imagesBrandingController();
+      await controller.$onInit();
+      await $scope.submit();
+      chai.expect($log.error.called).to.be.false;
+      chai.expect($scope.doc).to.deep.be.equal({title: '', resources: {}});
+    });
+  });
+});


### PR DESCRIPTION
# Description

When an empty branding JSON is uploaded via the `cht` tool the branding controller assumed certain keys existed in order to populate various $scope objects thus throwing an exception when they where were missing. Now the code checks if they exists exist and if they don't it creates a minimal set of keys in the objects that the template needs to work.

I created a test to validate the issue following similar conventions as other tests since this controller was lacking tests.

medic/cht-core#8026

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

